### PR TITLE
Basic maintenance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,9 @@ repository = "https://github.com/DMSrs/poppler-rs"
 edition = "2018"
 
 [dependencies]
+# "pdf" and "png" are test dependencies. Remove them once Cargo has support
+cairo-rs = { git = "https://github.com/gtk-rs/gtk-rs-core", features = ["v1_16", "pdf", "png"] }
 poppler-sys = { version = "0.1.0", path = "poppler-sys" }
-cairo-rs =  { version = "0.9.1", features = ["v1_16", "use_glib", "png", "pdf"] }
-cairo-sys-rs = { version = "0.10.0" }
-glib = { version = "0.10.3" }
-glib-sys = { version = "0.10.1" }
-gobject-sys = { version = "0.10.0" }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,11 @@ edition = "2018"
 
 [dependencies]
 poppler-sys = { version = "0.1.0", path = "poppler-sys" }
-cairo-rs = { version = "0.9.1", features = ["png", "pdf"] }
-glib = "0.10.1"
-glib-sys = "0.10.0"
-gobject-sys = "0.10.0"
+cairo-rs =  { git = "https://github.com/gtk-rs/cairo", features = ["v1_16", "use_glib", "png", "pdf"] }
+cairo-sys-rs = { git = "https://github.com/gtk-rs/cairo" }
+glib = { git = "https://github.com/gtk-rs/glib" }
+glib-sys = { git = "https://github.com/gtk-rs/sys" }
+gobject-sys = { git = "https://github.com/gtk-rs/sys" }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 authors = [
     "Marc Brinkmann <git@marcbrinkmann.de>",
-    "Denys Vitali <denys@denv.it>"
+    "Denys Vitali <denys@denv.it>",
+    "piegames <git@piegames.de>",
 ]
 name = "poppler"
 license = "GPL-2.0"
-version = "0.3.1"
+version = "0.4.0"
 description = "Wrapper for the GPL-licensed Poppler PDF rendering library."
 repository = "https://github.com/DMSrs/poppler-rs"
 edition = "2018"
@@ -13,7 +14,7 @@ edition = "2018"
 [dependencies]
 # "pdf" and "png" are test dependencies. Remove them once Cargo has support
 cairo-rs = { version = ">=0.14, <1", features = ["v1_16", "pdf", "png"] }
-poppler-sys = { version = "0.1.0", path = "poppler-sys" }
+poppler-sys = { version = "0.2.0", path = "poppler-sys" }
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 # "pdf" and "png" are test dependencies. Remove them once Cargo has support
-cairo-rs = { version = "0.14", features = ["v1_16", "pdf", "png"] }
+cairo-rs = { version = ">=0.14, <1", features = ["v1_16", "pdf", "png"] }
 poppler-sys = { version = "0.1.0", path = "poppler-sys" }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 # "pdf" and "png" are test dependencies. Remove them once Cargo has support
-cairo-rs = { git = "https://github.com/gtk-rs/gtk-rs-core", features = ["v1_16", "pdf", "png"] }
+cairo-rs = { version = "0.14", features = ["v1_16", "pdf", "png"] }
 poppler-sys = { version = "0.1.0", path = "poppler-sys" }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ edition = "2018"
 
 [dependencies]
 poppler-sys = { version = "0.1.0", path = "poppler-sys" }
-cairo-rs =  { git = "https://github.com/gtk-rs/cairo", features = ["v1_16", "use_glib", "png", "pdf"] }
-cairo-sys-rs = { git = "https://github.com/gtk-rs/cairo" }
-glib = { git = "https://github.com/gtk-rs/glib" }
-glib-sys = { git = "https://github.com/gtk-rs/sys" }
-gobject-sys = { git = "https://github.com/gtk-rs/sys" }
+cairo-rs =  { version = "0.9.1", features = ["v1_16", "use_glib", "png", "pdf"] }
+cairo-sys-rs = { version = "0.10.0" }
+glib = { version = "0.10.3" }
+glib-sys = { version = "0.10.1" }
+gobject-sys = { version = "0.10.0" }
 
 [features]
 default = []

--- a/poppler-sys/Cargo.toml
+++ b/poppler-sys/Cargo.toml
@@ -13,14 +13,11 @@ keywords = ["poppler"]
 categories = ["external-ffi-bindings"]
 build = "build.rs"
 links = "poppler-glib"
+edition = "2018"
 
 [dependencies]
-cairo-rs =  { version = "0.9.1", features = ["v1_16", "use_glib", "png", "pdf"] }
-cairo-sys-rs = { version = "0.10.0" }
-glib = { version = "0.10.3" }
-glib-sys = { version = "0.10.1" }
-gobject-sys = { version = "0.10.0" }
-gio-sys = { version = "0.10.1" }
+cairo-rs = { git = "https://github.com/gtk-rs/gtk-rs-core", features = ["v1_16"] }
+gio-sys = { git = "https://github.com/gtk-rs/gtk-rs-core" }
 gtypes = "0.2.0"
 
 [build-dependencies]

--- a/poppler-sys/Cargo.toml
+++ b/poppler-sys/Cargo.toml
@@ -15,12 +15,12 @@ build = "build.rs"
 links = "poppler-glib"
 
 [dependencies]
-cairo-rs =  { git = "https://github.com/gtk-rs/cairo", features = ["v1_16", "use_glib", "png", "pdf"] }
-cairo-sys-rs = { git = "https://github.com/gtk-rs/cairo" }
-glib = { git = "https://github.com/gtk-rs/glib" }
-glib-sys = { git = "https://github.com/gtk-rs/sys" }
-gobject-sys = { git = "https://github.com/gtk-rs/sys" }
-gio-sys = { git = "https://github.com/gtk-rs/sys" }
+cairo-rs =  { version = "0.9.1", features = ["v1_16", "use_glib", "png", "pdf"] }
+cairo-sys-rs = { version = "0.10.0" }
+glib = { version = "0.10.3" }
+glib-sys = { version = "0.10.1" }
+gobject-sys = { version = "0.10.0" }
+gio-sys = { version = "0.10.1" }
 gtypes = "0.2.0"
 
 [build-dependencies]

--- a/poppler-sys/Cargo.toml
+++ b/poppler-sys/Cargo.toml
@@ -16,8 +16,8 @@ links = "poppler-glib"
 edition = "2018"
 
 [dependencies]
-cairo-rs = { git = "https://github.com/gtk-rs/gtk-rs-core", features = ["v1_16"] }
-gio-sys = { git = "https://github.com/gtk-rs/gtk-rs-core" }
+cairo-rs = { version = "0.14", features = ["v1_16"] }
+gio-sys = { version = "0.14" }
 gtypes = "0.2.0"
 
 [build-dependencies]

--- a/poppler-sys/Cargo.toml
+++ b/poppler-sys/Cargo.toml
@@ -15,12 +15,12 @@ build = "build.rs"
 links = "poppler-glib"
 
 [dependencies]
-cairo-rs = { version = "0.9.1", features = ["png", "pdf"] }
-cairo-sys-rs = "0.10.0"
-glib = "0.10.1"
-glib-sys = "0.10.0"
-gobject-sys = "0.10.0"
-gio-sys = "0.10.0"
+cairo-rs =  { git = "https://github.com/gtk-rs/cairo", features = ["v1_16", "use_glib", "png", "pdf"] }
+cairo-sys-rs = { git = "https://github.com/gtk-rs/cairo" }
+glib = { git = "https://github.com/gtk-rs/glib" }
+glib-sys = { git = "https://github.com/gtk-rs/sys" }
+gobject-sys = { git = "https://github.com/gtk-rs/sys" }
+gio-sys = { git = "https://github.com/gtk-rs/sys" }
 gtypes = "0.2.0"
 
 [build-dependencies]

--- a/poppler-sys/Cargo.toml
+++ b/poppler-sys/Cargo.toml
@@ -16,8 +16,8 @@ links = "poppler-glib"
 edition = "2018"
 
 [dependencies]
-cairo-rs = { version = "0.14", features = ["v1_16"] }
-gio-sys = { version = "0.14" }
+cairo-rs = { version = ">=0.14, <1", features = ["v1_16"] }
+gio-sys = { version = ">=0.14, <1" }
 gtypes = "0.2.0"
 
 [build-dependencies]

--- a/poppler-sys/Cargo.toml
+++ b/poppler-sys/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "poppler-sys"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
     "Marc Brinkmann <git@marcbrinkmann.de>",
     "Denys Vitali <denys@denv.it>",
-    "Thiago Machado <swfsql@gmail.com>"
+    "Thiago Machado <swfsql@gmail.com>",
+    "piegames <git@piegames.de>",
 ]
 repository = "https://github.com/DMSrs/poppler-rs"
 license = "GPL-2.0"

--- a/poppler-sys/build.rs
+++ b/poppler-sys/build.rs
@@ -173,43 +173,43 @@ lazy_static! {
         let mut m = HashMap::new();
         m.insert(
             Modules::Poppler,
-            WHITELIST_POPPLER.into_iter().cloned().collect(),
+            WHITELIST_POPPLER.iter().cloned().collect(),
         );
         m.insert(
             Modules::PopplerDocument,
-            WHITELIST_POPPLER_DOCUMENT.into_iter().cloned().collect(),
+            WHITELIST_POPPLER_DOCUMENT.iter().cloned().collect(),
         );
         m.insert(
             Modules::PopplerPage,
-            WHITELIST_POPPLER_PAGE.into_iter().cloned().collect(),
+            WHITELIST_POPPLER_PAGE.iter().cloned().collect(),
         );
         m.insert(
             Modules::PopplerAction,
-            WHITELIST_POPPLER_ACTION.into_iter().cloned().collect(),
+            WHITELIST_POPPLER_ACTION.iter().cloned().collect(),
         );
         m.insert(
             Modules::PopplerAnnot,
-            WHITELIST_POPPLER_ANNOT.into_iter().cloned().collect(),
+            WHITELIST_POPPLER_ANNOT.iter().cloned().collect(),
         );
         m.insert(
             Modules::PopplerAttachment,
-            WHITELIST_POPPLER_ATTACHMENT.into_iter().cloned().collect(),
+            WHITELIST_POPPLER_ATTACHMENT.iter().cloned().collect(),
         );
         m.insert(
             Modules::PopplerFormField,
-            WHITELIST_POPPLER_FORM_FIELD.into_iter().cloned().collect(),
+            WHITELIST_POPPLER_FORM_FIELD.iter().cloned().collect(),
         );
         m.insert(
             Modules::PopplerLayer,
-            WHITELIST_POPPLER_LAYER.into_iter().cloned().collect(),
+            WHITELIST_POPPLER_LAYER.iter().cloned().collect(),
         );
         m.insert(
             Modules::PopplerMedia,
-            WHITELIST_POPPLER_MEDIA.into_iter().cloned().collect(),
+            WHITELIST_POPPLER_MEDIA.iter().cloned().collect(),
         );
         m.insert(
             Modules::PopplerMovie,
-            WHITELIST_POPPLER_MOVIE.into_iter().cloned().collect(),
+            WHITELIST_POPPLER_MOVIE.iter().cloned().collect(),
         );
         m
     };
@@ -217,7 +217,7 @@ lazy_static! {
         let mut m = HashMap::new();
         m.insert(
             Modules::Poppler,
-            WHITELIST_FUNC_POPPLER.into_iter().cloned().collect(),
+            WHITELIST_FUNC_POPPLER.iter().cloned().collect(),
         );
         m
     };

--- a/poppler-sys/src/lib.rs
+++ b/poppler-sys/src/lib.rs
@@ -6,20 +6,12 @@
     improper_ctypes
 )]
 
-extern crate cairo;
-extern crate cairo_sys;
-extern crate gio_sys;
-extern crate glib;
-extern crate glib_sys;
-extern crate gobject_sys;
-extern crate gtypes;
-
 mod dep_types {
-    pub use cairo_sys::{cairo_region_t, cairo_surface_t, cairo_t};
-    pub use glib_sys::{
+    pub use cairo::ffi::{cairo_region_t, cairo_surface_t, cairo_t};
+    pub use cairo::glib::ffi::{
         gboolean, gpointer, GArray, GDate, GError, GList, GQuark, GString, GTime, GType, GTree, GBytes
     };
-    pub use gobject_sys::{GObject, GObjectClass};
+    pub use cairo::glib::gobject_ffi::{GObject, GObjectClass};
     pub use gtypes::{gchar, gdouble, gint, gsize, guint, gushort};
     pub type guint64 = u64;
     pub use std::os::raw::{c_char, c_int, c_long, c_uchar, c_uint, c_ulong, c_ushort};

--- a/src/document.rs
+++ b/src/document.rs
@@ -149,3 +149,13 @@ impl PopplerDocument {
         }
     }
 }
+
+// TODO replace Box<dyn FnMut> with an opaque type once we have existential types
+impl <'a> std::iter::IntoIterator for &'a PopplerDocument {
+    type Item = PopplerPage;
+    type IntoIter = std::iter::Map<std::ops::Range<usize>, Box<dyn FnMut(usize) -> Self::Item + 'a>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        (0..self.n_pages()).map(Box::new(move |page| self.page(page).expect("Poppler internal error: PDF is missing a page?!")))
+    }
+}

--- a/src/document.rs
+++ b/src/document.rs
@@ -4,6 +4,7 @@ use poppler_sys::{poppler as sys, poppler_document as sys_doc};
 use std::ffi::CString;
 use std::os::raw::{c_char, c_int};
 use std::path;
+use cairo::glib;
 
 #[derive(Debug)]
 pub struct PopplerDocument(*mut sys::PopplerDocument);

--- a/src/document.rs
+++ b/src/document.rs
@@ -31,7 +31,7 @@ impl PopplerDocument {
         data: &mut [u8],
         password: &str,
     ) -> Result<PopplerDocument, glib::error::Error> {
-        if data.len() == 0 {
+        if data.is_empty() {
             return Err(glib::error::Error::new(
                 glib::FileError::Inval,
                 "data is empty",

--- a/src/document.rs
+++ b/src/document.rs
@@ -55,6 +55,27 @@ impl PopplerDocument {
 
         Ok(PopplerDocument(doc))
     }
+    pub fn new_from_bytes(
+        bytes: glib::Bytes,
+        password: &str,
+    ) -> Result<PopplerDocument, glib::error::Error> {
+        let pw = CString::new(password).map_err(|_| {
+            glib::error::Error::new(
+                glib::FileError::Inval,
+                "Password invalid (possibly contains NUL characters)",
+            )
+        })?;
+        use glib::translate::ToGlibPtr;
+        let doc = util::call_with_gerror(|err_ptr| unsafe {
+            sys_doc::poppler_document_new_from_bytes(
+                bytes.to_glib_full(),
+                pw.as_ptr(),
+                err_ptr,
+            )
+        })?;
+
+        Ok(PopplerDocument(doc))
+    }
     pub fn get_title(&self) -> Option<String> {
         unsafe {
             let ptr: *mut c_char = sys_doc::poppler_document_get_title(self.0);

--- a/src/document.rs
+++ b/src/document.rs
@@ -10,7 +10,9 @@ use cairo::glib;
 pub struct PopplerDocument(*mut sys::PopplerDocument);
 
 impl PopplerDocument {
-    pub fn new_from_file<P: AsRef<path::Path>>(
+    #[doc(alias = "poppler_document_new_from_file")]
+    #[doc(alias = "new_from_file")]
+    pub fn from_file<P: AsRef<path::Path>>(
         p: P,
         password: &str,
     ) -> Result<PopplerDocument, glib::error::Error> {
@@ -28,7 +30,11 @@ impl PopplerDocument {
 
         Ok(PopplerDocument(doc))
     }
-    pub fn new_from_data(
+
+    #[doc(alias = "poppler_document_new_from_data")]
+    #[doc(alias = "new_from_data")]
+    #[deprecated(note = "[`from_data`] has been deprecated since version 0.82 and should not be used in newly-written code. This requires directly managing length and data . Use [`from_bytes`] instead.", since = "Poppler v0.82")]
+    pub fn from_data(
         data: &mut [u8],
         password: &str,
     ) -> Result<PopplerDocument, glib::error::Error> {
@@ -56,7 +62,10 @@ impl PopplerDocument {
 
         Ok(PopplerDocument(doc))
     }
-    pub fn new_from_bytes(
+
+    #[doc(alias = "poppler_document_new_from_bytes")]
+    #[doc(alias = "new_from_bytes")]
+    pub fn from_bytes(
         bytes: glib::Bytes,
         password: &str,
     ) -> Result<PopplerDocument, glib::error::Error> {
@@ -77,7 +86,10 @@ impl PopplerDocument {
 
         Ok(PopplerDocument(doc))
     }
-    pub fn get_title(&self) -> Option<String> {
+
+    #[doc(alias = "poppler_document_get_title")]
+    #[doc(alias = "get_title")]
+    pub fn title(&self) -> Option<String> {
         unsafe {
             let ptr: *mut c_char = sys_doc::poppler_document_get_title(self.0);
             if ptr.is_null() {
@@ -87,7 +99,10 @@ impl PopplerDocument {
             }
         }
     }
-    pub fn get_metadata(&self) -> Option<String> {
+
+    #[doc(alias = "poppler_document_get_metadata")]
+    #[doc(alias = "get_metadata")]
+    pub fn metadata(&self) -> Option<String> {
         unsafe {
             let ptr: *mut c_char = sys_doc::poppler_document_get_metadata(self.0);
             if ptr.is_null() {
@@ -97,7 +112,10 @@ impl PopplerDocument {
             }
         }
     }
-    pub fn get_pdf_version_string(&self) -> Option<String> {
+
+    #[doc(alias = "poppler_document_get_pdf_version_string")]
+    #[doc(alias = "get_pdf_version_string")]
+    pub fn pdf_version_string(&self) -> Option<String> {
         unsafe {
             let ptr: *mut c_char = sys_doc::poppler_document_get_pdf_version_string(self.0);
             if ptr.is_null() {
@@ -107,17 +125,24 @@ impl PopplerDocument {
             }
         }
     }
-    pub fn get_permissions(&self) -> u8 {
+
+    #[doc(alias = "poppler_document_get_permissions")]
+    #[doc(alias = "get_permissions")]
+    pub fn permissions(&self) -> u8 {
         unsafe { sys_doc::poppler_document_get_permissions(self.0) as u8 }
     }
 
-    pub fn get_n_pages(&self) -> usize {
+    #[doc(alias = "poppler_document_get_n_pages")]
+    #[doc(alias = "get_n_pages")]
+    pub fn n_pages(&self) -> usize {
         // FIXME: what's the correct type here? can we assume a document
         //        has a positive number of pages?
         (unsafe { sys_doc::poppler_document_get_n_pages(self.0) }) as usize
     }
 
-    pub fn get_page(&self, index: usize) -> Option<PopplerPage> {
+    #[doc(alias = "poppler_document_get_page")]
+    #[doc(alias = "get_page")]
+    pub fn page(&self, index: usize) -> Option<PopplerPage> {
         match unsafe { sys_doc::poppler_document_get_page(self.0, index as c_int) } {
             ptr if ptr.is_null() => None,
             ptr => Some(PopplerPage::new(ptr)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,3 @@
-extern crate cairo;
-extern crate glib;
-extern crate glib_sys;
-extern crate poppler_sys;
-
 mod document;
 mod page;
 mod util;

--- a/src/page.rs
+++ b/src/page.rs
@@ -6,11 +6,14 @@ use std::os::raw::c_double;
 pub struct PopplerPage(*mut sys::PopplerPage);
 
 impl PopplerPage {
+    #[doc(hidden)]
     pub fn new(ptr: *mut sys::PopplerPage) -> Self {
         PopplerPage(ptr)
     }
 
-    pub fn get_size(&self) -> (f64, f64) {
+    #[doc(alias = "poppler_page_get_size")]
+    #[doc(alias = "get_size")]
+    pub fn size(&self) -> (f64, f64) {
         let mut width: f64 = 0.0;
         let mut height: f64 = 0.0;
 
@@ -25,19 +28,23 @@ impl PopplerPage {
         (width, height)
     }
 
+    #[doc(alias = "poppler_page_render")]
     pub fn render(&self, ctx: &cairo::Context) -> Result<(), cairo::Error> {
         let ctx_raw = ctx.to_raw_none();
         unsafe { sys_pg::poppler_page_render(self.0, ctx_raw) };
         ctx.status()
     }
 
+    #[doc(alias = "poppler_page_render_for_printing")]
     pub fn render_for_printing(&self, ctx: &cairo::Context) -> Result<(), cairo::Error> {
         let ctx_raw = ctx.to_raw_none();
         unsafe { sys_pg::poppler_page_render_for_printing(self.0, ctx_raw) };
         ctx.status()
     }
 
-    pub fn get_text(&self) -> Option<&str> {
+    #[doc(alias = "poppler_page_get_text")]
+    #[doc(alias = "get_text")]
+    pub fn text(&self) -> Option<&str> {
         match unsafe { sys_pg::poppler_page_get_text(self.0) } {
             ptr if ptr.is_null() => None,
             ptr => unsafe { Some(CStr::from_ptr(ptr).to_str().unwrap()) },

--- a/src/page.rs
+++ b/src/page.rs
@@ -25,14 +25,16 @@ impl PopplerPage {
         (width, height)
     }
 
-    pub fn render(&self, ctx: &cairo::Context) {
+    pub fn render(&self, ctx: &cairo::Context) -> Result<(), cairo::Error> {
         let ctx_raw = ctx.to_raw_none();
-        unsafe { sys_pg::poppler_page_render(self.0, ctx_raw) }
+        unsafe { sys_pg::poppler_page_render(self.0, ctx_raw) };
+        ctx.status()
     }
 
-    pub fn render_for_printing(&self, ctx: &cairo::Context) {
+    pub fn render_for_printing(&self, ctx: &cairo::Context) -> Result<(), cairo::Error> {
         let ctx_raw = ctx.to_raw_none();
-        unsafe { sys_pg::poppler_page_render_for_printing(self.0, ctx_raw) }
+        unsafe { sys_pg::poppler_page_render_for_printing(self.0, ctx_raw) };
+        ctx.status()
     }
 
     pub fn get_text(&self) -> Option<&str> {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,6 @@
+use cairo::glib;
 use glib::translate::from_glib_full;
-use glib_sys::GError;
+use glib::ffi::GError;
 use std::ffi::{CString, OsString};
 use std::{fs, path, ptr};
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,3 @@
-use glib;
 use glib::translate::from_glib_full;
 use glib_sys::GError;
 use std::ffi::{CString, OsString};

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,14 +1,9 @@
-extern crate cairo;
-extern crate glib;
-extern crate glib_sys;
-extern crate poppler;
-
 use cairo::{Context, Format, ImageSurface, PdfSurface};
 use poppler::{PopplerDocument, PopplerPage};
 use std::{fs::File, io::Read};
 
 #[test]
-fn test1() {
+fn test1() -> Result<(), cairo::Error> {
     let filename = "tests/test.pdf";
     let doc = PopplerDocument::new_from_file(filename, "").unwrap();
     let num_pages = doc.get_n_pages();
@@ -16,30 +11,31 @@ fn test1() {
     println!("Document has {} page(s)", num_pages);
 
     let mut surface = PdfSurface::new(420.0, 595.0, "tests/output.pdf").unwrap();
-    let ctx = Context::new(&mut surface);
+    let ctx = Context::new(&mut surface)?;
 
     // FIXME: move iterator to poppler
     for page_num in 0..num_pages {
         let page = doc.get_page(page_num).unwrap();
         let (w, h) = page.get_size();
         println!("page {} has size {}, {}", page_num, w, h);
-        surface.set_size(w, h);
+        surface.set_size(w, h)?;
 
-        ctx.save();
+        ctx.save()?;
         page.render(&ctx);
 
         println!("Text: {:?}", page.get_text().unwrap_or(""));
 
-        ctx.restore();
-        ctx.show_page();
+        ctx.restore()?;
+        ctx.show_page()?;
     }
     // g_object_unref (page);
     //surface.write_to_png("file.png");
     surface.finish();
+    Ok(())
 }
 
 #[test]
-fn test2_from_file() {
+fn test2_from_file() -> Result<(), cairo::Error> {
     let path = "tests/test.pdf";
     let doc: PopplerDocument = PopplerDocument::new_from_file(path, "upw").unwrap();
     let num_pages = doc.get_n_pages();
@@ -66,15 +62,16 @@ fn test2_from_file() {
     assert_eq!(title, "This is a test PDF file");
 
     let mut surface = ImageSurface::create(Format::ARgb32, w as i32, h as i32).unwrap();
-    let ctx = Context::new(&mut surface);
+    let ctx = Context::new(&mut surface)?;
 
-    ctx.save();
+    ctx.save()?;
     page.render(&ctx);
-    ctx.restore();
-    ctx.show_page();
+    ctx.restore()?;
+    ctx.show_page()?;
 
     let mut f: File = File::create("tests/out.png").unwrap();
     surface.write_to_png(&mut f).expect("Unable to write PNG");
+    Ok(())
 }
 #[test]
 fn test2_from_data() {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -13,9 +13,7 @@ fn test1() -> Result<(), cairo::Error> {
     let mut surface = PdfSurface::new(420.0, 595.0, "tests/output.pdf").unwrap();
     let ctx = Context::new(&mut surface)?;
 
-    // FIXME: move iterator to poppler
-    for page_num in 0..num_pages {
-        let page = doc.page(page_num).unwrap();
+    for (page_num, page) in doc.into_iter().enumerate() {
         let (w, h) = page.size();
         println!("page {} has size {}, {}", page_num, w, h);
         surface.set_size(w, h)?;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -21,7 +21,7 @@ fn test1() -> Result<(), cairo::Error> {
         surface.set_size(w, h)?;
 
         ctx.save()?;
-        page.render(&ctx);
+        page.render(&ctx)?;
 
         println!("Text: {:?}", page.get_text().unwrap_or(""));
 
@@ -65,7 +65,7 @@ fn test2_from_file() -> Result<(), cairo::Error> {
     let ctx = Context::new(&mut surface)?;
 
     ctx.save()?;
-    page.render(&ctx);
+    page.render(&ctx)?;
     ctx.restore()?;
     ctx.show_page()?;
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,8 +5,8 @@ use std::{fs::File, io::Read};
 #[test]
 fn test1() -> Result<(), cairo::Error> {
     let filename = "tests/test.pdf";
-    let doc = PopplerDocument::new_from_file(filename, "").unwrap();
-    let num_pages = doc.get_n_pages();
+    let doc = PopplerDocument::from_file(filename, "").unwrap();
+    let num_pages = doc.n_pages();
 
     println!("Document has {} page(s)", num_pages);
 
@@ -15,15 +15,15 @@ fn test1() -> Result<(), cairo::Error> {
 
     // FIXME: move iterator to poppler
     for page_num in 0..num_pages {
-        let page = doc.get_page(page_num).unwrap();
-        let (w, h) = page.get_size();
+        let page = doc.page(page_num).unwrap();
+        let (w, h) = page.size();
         println!("page {} has size {}, {}", page_num, w, h);
         surface.set_size(w, h)?;
 
         ctx.save()?;
         page.render(&ctx)?;
 
-        println!("Text: {:?}", page.get_text().unwrap_or(""));
+        println!("Text: {:?}", page.text().unwrap_or(""));
 
         ctx.restore()?;
         ctx.show_page()?;
@@ -37,14 +37,14 @@ fn test1() -> Result<(), cairo::Error> {
 #[test]
 fn test2_from_file() -> Result<(), cairo::Error> {
     let path = "tests/test.pdf";
-    let doc: PopplerDocument = PopplerDocument::new_from_file(path, "upw").unwrap();
-    let num_pages = doc.get_n_pages();
-    let title = doc.get_title().unwrap();
-    let metadata = doc.get_metadata();
-    let version_string = doc.get_pdf_version_string();
-    let permissions = doc.get_permissions();
-    let page: PopplerPage = doc.get_page(0).unwrap();
-    let (w, h) = page.get_size();
+    let doc: PopplerDocument = PopplerDocument::from_file(path, "upw").unwrap();
+    let num_pages = doc.n_pages();
+    let title = doc.title().unwrap();
+    let metadata = doc.metadata();
+    let version_string = doc.pdf_version_string();
+    let permissions = doc.permissions();
+    let page: PopplerPage = doc.page(0).unwrap();
+    let (w, h) = page.size();
 
     println!(
         "Document {} has {} page(s) and is {}x{}",
@@ -73,20 +73,21 @@ fn test2_from_file() -> Result<(), cairo::Error> {
     surface.write_to_png(&mut f).expect("Unable to write PNG");
     Ok(())
 }
+
 #[test]
 fn test2_from_data() {
     let path = "tests/test.pdf";
     let mut file = File::open(path).unwrap();
     let mut data: Vec<u8> = Vec::new();
     file.read_to_end(&mut data).unwrap();
-    let doc: PopplerDocument = PopplerDocument::new_from_data(&mut data[..], "upw").unwrap();
-    let num_pages = doc.get_n_pages();
-    let title = doc.get_title().unwrap();
-    let metadata = doc.get_metadata();
-    let version_string = doc.get_pdf_version_string();
-    let permissions = doc.get_permissions();
-    let page: PopplerPage = doc.get_page(0).unwrap();
-    let (w, h) = page.get_size();
+    let doc: PopplerDocument = PopplerDocument::from_data(&mut data[..], "upw").unwrap();
+    let num_pages = doc.n_pages();
+    let title = doc.title().unwrap();
+    let metadata = doc.metadata();
+    let version_string = doc.pdf_version_string();
+    let permissions = doc.permissions();
+    let page: PopplerPage = doc.page(0).unwrap();
+    let (w, h) = page.size();
 
     println!(
         "Document {} has {} page(s) and is {}x{}",
@@ -106,5 +107,5 @@ fn test2_from_data() {
 fn test3() {
     let mut data = vec![];
 
-    assert!(PopplerDocument::new_from_data(&mut data[..], "upw").is_err());
+    assert!(PopplerDocument::from_data(&mut data[..], "upw").is_err());
 }


### PR DESCRIPTION
- Bumped dependencies. Current GTK-rs version: 0.14.0
- Removed compiler warnings
- Added `PopplerDocument::new_from_bytes` as a better alternative to `new_from_data`.
- `render` and `render_for_printing` now return a `Result`.